### PR TITLE
Disable es.weso.schema.ValidationTrigger logging.

### DIFF
--- a/modules/core/src/main/resources/logback.xml
+++ b/modules/core/src/main/resources/logback.xml
@@ -29,5 +29,6 @@
     <logger name="akka.remote" level="WARN" />
     <logger name="akka.cluster" level="WARN" />
     <logger name="es.weso.shacl" level="WARN" />
+    <logger name="es.weso.schema" level="WARN" />
 
 </configuration>


### PR DESCRIPTION
We're currently getting a lot of log entries like this:
```
2018-04-13 09:23:48 INFO  es.weso.schema.ValidationTrigger$ - Finding trigger TargetDecls, shapeMapStr:
Trying to match /^[a-z]{1}[a-z0-9-_]*$/ with nxv
Result of match /^[a-z]{1}[a-z0-9-_]*$/ with nxv = true
Trying to match /^[a-z]{1}[a-z0-9-_]*$/ with person
Result of match /^[a-z]{1}[a-z0-9-_]*$/ with person = true
```
which are unnecessarily verbose.
We need to disable them.
