### PR TITLE
Make authn and authz handling explicit through errors

### DIFF
--- a/src/main/scala/ch/epfl/bluebrain/nexus/admin/exceptions/AdminError.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/admin/exceptions/AdminError.scala
@@ -48,6 +48,17 @@ object AdminError {
     */
   final case object NotFound extends AdminError("The requested resource could not be found.")
 
+  /**
+    * Signals that the provided authentication is not valid.
+    */
+  final case object AuthenticationFailed extends AdminError("The supplied authentication is invalid.")
+
+  /**
+    * Signals that the caller doesn't have access to the selected resource.
+    */
+  final case object AuthorizationFailed
+      extends AdminError("The supplied authentication is not authorized to access this resource.")
+
   implicit val adminErrorEncoder: Encoder[AdminError] = {
     implicit val rejectionConfig: Configuration = Configuration.default.withDiscriminator("@type")
     val enc                                     = deriveEncoder[AdminError].mapJson(_ addContext errorCtxUri)
@@ -55,7 +66,9 @@ object AdminError {
   }
 
   implicit val adminErrorStatusFrom: StatusFrom[AdminError] = {
-    case NotFound => StatusCodes.NotFound
-    case _        => StatusCodes.InternalServerError
+    case NotFound             => StatusCodes.NotFound
+    case AuthenticationFailed => StatusCodes.Unauthorized
+    case AuthorizationFailed  => StatusCodes.Forbidden
+    case _                    => StatusCodes.InternalServerError
   }
 }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/admin/routes/Routes.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/admin/routes/Routes.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.server.{ExceptionHandler, RejectionHandler, Route}
 import ch.epfl.bluebrain.nexus.admin.config.AppConfig
 import ch.epfl.bluebrain.nexus.admin.config.AppConfig.{HttpConfig, PaginationConfig, PersistenceConfig}
 import ch.epfl.bluebrain.nexus.admin.exceptions.AdminError
-import ch.epfl.bluebrain.nexus.admin.exceptions.AdminError.{InternalError, NotFound}
+import ch.epfl.bluebrain.nexus.admin.exceptions.AdminError._
 import ch.epfl.bluebrain.nexus.admin.marshallers.instances._
 import ch.epfl.bluebrain.nexus.admin.organizations.{OrganizationRejection, Organizations}
 import ch.epfl.bluebrain.nexus.admin.projects.{ProjectRejection, Projects}
@@ -36,6 +36,12 @@ object Routes {
       case NotFound =>
         // suppress errors for not found
         complete(AdminError.adminErrorStatusFrom(NotFound) -> (NotFound: AdminError))
+      case AuthenticationFailed =>
+        // suppress errors for authentication failures
+        complete(AdminError.adminErrorStatusFrom(AuthenticationFailed) -> (AuthenticationFailed: AdminError))
+      case AuthorizationFailed =>
+        // suppress errors for authorization failures
+        complete(AdminError.adminErrorStatusFrom(AuthorizationFailed) -> (AuthorizationFailed: AdminError))
       case err =>
         logger.error("Exception caught during routes processing ", err)
         val error: AdminError = InternalError("The system experienced an unexpected error, please try again later.")


### PR DESCRIPTION
The multiple concatenated routes can yield arbitrary rejections if route processing is not halted at the first authn or authz rejection.

For example yielding an `AuthenticationFailedRejection` will not complete the route if there's another route that matches the same path but with a different method. The result in this case will be
`MethodNotAllowed` when actually the expected result should be `Unauthorized`.