### PR TITLE
Fixed ddata based indexing serialization preventing clustering

### DIFF
--- a/src/main/resources/akka.conf
+++ b/src/main/resources/akka.conf
@@ -47,11 +47,14 @@ akka {
 
     serialization-bindings {
       "ch.epfl.bluebrain.nexus.admin.organizations.OrganizationEvent" = circeEvent
-      "ch.epfl.bluebrain.nexus.admin.projects.ProjectEvent" = circeEvent
+      "ch.epfl.bluebrain.nexus.admin.projects.ProjectEvent"           = circeEvent
 
-      "ch.epfl.bluebrain.nexus.sourcing.akka.Msg" = kryo,
+      "ch.epfl.bluebrain.nexus.sourcing.akka.Msg" = kryo
       "ch.epfl.bluebrain.nexus.service.indexer.stream.StreamCoordinator$Stop$" = kryo
       "ch.epfl.bluebrain.nexus.service.indexer.stream.StreamCoordinator$Start" = kryo
+
+      "java.util.UUID"                                = kryo
+      "ch.epfl.bluebrain.nexus.admin.types.ResourceF" = kryo
 
       "scala.runtime.BoxedUnit" = kryo
       "akka.actor.Status$Failure" = kryo


### PR DESCRIPTION
The types `java.lang.UUID` and `ResourceF` were not listed in the serialization bindings. With java serialization disabled in a cluster setup the distributed data based implementation of the KeyValueStore would fail to ship updates across nodes for changes to mappings `UUID -> ResourceF[_]`.