### PR TITLE
Added fetchProjects method to client module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ scalafmt: {
 
 // Dependency versions
 val alpakkaVersion             = "1.1.1"
-val commonsVersion             = "0.17.6"
+val commonsVersion             = "0.17.8"
 val iamVersion                 = "310fb2cd"
 val sourcingVersion            = "0.16.5"
 val akkaVersion                = "2.5.25"

--- a/client/src/main/scala/ch/epfl/bluebrain/nexus/admin/client/types/Project.scala
+++ b/client/src/main/scala/ch/epfl/bluebrain/nexus/admin/client/types/Project.scala
@@ -3,6 +3,7 @@ package ch.epfl.bluebrain.nexus.admin.client.types
 import java.time.Instant
 import java.util.UUID
 
+import cats.Show
 import ch.epfl.bluebrain.nexus.rdf.Iri
 import ch.epfl.bluebrain.nexus.rdf.Iri.AbsoluteIri
 import ch.epfl.bluebrain.nexus.rdf.instances._
@@ -56,6 +57,8 @@ object Project {
       iri       <- Iri.absolute(namespace).left.map(err => DecodingFailure(err, hc.history))
     } yield Mapping(prefix, iri)
   }
+
+  implicit val projectShow: Show[Project] = Show.show(project => s"${project.organizationLabel}/${project.label}")
 
   /**
     * JSON decoder for [[Project]].

--- a/client/src/test/resources/project.json
+++ b/client/src/test/resources/project.json
@@ -20,7 +20,7 @@
     }
   ],
   "description": "Test project",
-  "_label": "testproject",
+  "_label": "{label}",
   "_organizationLabel": "testorg",
   "_organizationUuid": "504b6940-1b14-43a7-80e3-d08c52c3fc87",
   "_uuid": "db7cee63-3f93-4d4a-9cc2-ebdace7f3b4f",


### PR DESCRIPTION
Fetch all the projects from an organization. Implementation of the signature:

```scala
def fetchProjects(organization: String)(
      implicit credentials: Option[AuthToken]
): F[QueryResults[Project]] = ???


def fetchProjects(organization: String, page: FromPagination)(
      implicit credentials: Option[AuthToken]
  ): F[QueryResults[Project]] = ???
```